### PR TITLE
Address file descriptor leak in CDB_File

### DIFF
--- a/CDB_File.pm
+++ b/CDB_File.pm
@@ -6,7 +6,7 @@ use XSLoader ();
 use Exporter ();
 
 our @ISA       = qw(XSLoader Exporter);
-our $VERSION   = '1.00';
+our $VERSION   = '1.01';
 our @EXPORT_OK = qw(create);
 
 =head1 NAME

--- a/CDB_File.xs
+++ b/CDB_File.xs
@@ -692,7 +692,7 @@ cdbmaker_DESTROY(sv)
         CODE:
         if (sv_isobject(sv) && (SvTYPE(SvRV(sv)) == SVt_PVMG) ) {
           this = (cdb_make*)SvIV(SvRV(sv));
-          
+          if(this->f){PerlIO_close(this->f);}
           Safefree(this);
         }
 
@@ -816,6 +816,7 @@ cdbmaker_finish(this)
 
 	if (fsync(PerlIO_fileno(this->f)) == -1) XSRETURN_NO;
 	if (PerlIO_close(this->f) == EOF) XSRETURN_NO;
+     this->f=0;
 
 	if (rename(this->fntemp, this->fn)) XSRETURN_NO;
 	

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,9 @@
 Revision history for Perl extension CDB_File.
 
+1.01 - Todd Rinaldo <toddr@cpan.org> 2020-01-27
+    - Fix MANIFEST so Changelog is shpped.
+    - Address file descriptor leak in CDB_File.
+
 1.00 - Todd Rinaldo <toddr@cpan.org> 2020-01-19
     - Enable github actions for automated testing
     - Switch to github issues.

--- a/MANIFEST
+++ b/MANIFEST
@@ -2,11 +2,11 @@ ACKNOWLEDGE
 bun-x.pl
 CDB_File.pm
 CDB_File.xs
-CHANGES
+Changelog
 COPYRIGHT
 INSTALL
 Makefile.PL
-MANIFEST
+MANIFEST			This list of files
 MANIFEST.SKIP
 ppport.h
 README.md


### PR DESCRIPTION
I found file descriptor leak in CDB_File: cdbmaker_DESTROY does't close
opened file handle, so descriptors leak if no $cdb->finish method called.