### PR TITLE
support Perls with COW disabled

### DIFF
--- a/CDB_File.xs
+++ b/CDB_File.xs
@@ -71,8 +71,7 @@ EINVAL. */
 }
 #endif
 
-#define MIN_PERL_VERSION_FOR_COW  20
-#if PERL_REVISION >= 5 && PERL_VERSION >= MIN_PERL_VERSION_FOR_COW
+#if defined(SV_COW_REFCNT_MAX)
 #   define CDB_CAN_COW 1
 #else
 #   define CDB_CAN_COW 0


### PR DESCRIPTION
It's possible even after 5.20 to configure Perl and build time to disable COW.  This modifies the XS to detect via missing macros instead of via the Perl version number.

I made similar fixes to `B::COW` (https://github.com/atoomic/B-COW/pull/3) and `Clone` (https://github.com/garu/Clone/pull/28)