### PR TITLE
Don't abort search, if first found key doesn't match

### DIFF
--- a/CDB_File.xs
+++ b/CDB_File.xs
@@ -420,7 +420,7 @@ static int cdb_findnext(cdb *c, string_finder *to_find) {
                     case -1:
                         return -1;
                     case 0:
-                        return 0;
+                        continue;
                     default:
                         uint32_unpack(buf + 4,&c->dlen);
                         c->dpos = pos + 8 + next_key_len;

--- a/t/collision.t
+++ b/t/collision.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use Helpers;    # Local helper routines used by the test suite.
+
+use Test::More tests => 8;
+use CDB_File;
+
+my @keys = qw/Q5M QCX QK3 TPM QN5/;
+
+my ( $db, $db_tmp ) = get_db_file_pair(1);
+
+my $c = CDB_File->new( $db->filename, $db_tmp->filename );
+isa_ok( $c, 'CDB_File::Maker' );
+
+for my $k (@keys) {
+	$c->insert($k, 1);
+};
+is( $c->finish, 1, "Finish writes out" );
+
+my %h;
+tie( %h, "CDB_File", $db->filename );
+isa_ok( tied(%h), 'CDB_File' );
+
+for my $k (sort @keys) {
+   is( $h{$k}, 1, "$k matches" );
+}
+
+exit;


### PR DESCRIPTION
We could have multiple keys with the same hash sum in the CDB. So we
should not abort `cdb_findnext` if we found the hash, but it did not
matched the key to find.

This regression was introduced in f20fc80667bc26fd41aa3362310b2fe141253.

This fixes #26.